### PR TITLE
[Feat] 간단한 블로그 레이아웃 변경

### DIFF
--- a/quartz.config.ts
+++ b/quartz.config.ts
@@ -15,7 +15,7 @@ const config: QuartzConfig = {
     analytics: {
       provider: "plausible",
     },
-    locale: "en-US",
+    locale: "ko-KR",
     baseUrl: "quartz.jzhao.xyz",
     ignorePatterns: ["private", "templates", ".obsidian"],
     defaultDateType: "created",

--- a/quartz.config.ts
+++ b/quartz.config.ts
@@ -8,7 +8,7 @@ import * as Plugin from "./quartz/plugins"
  */
 const config: QuartzConfig = {
   configuration: {
-    pageTitle: "🪴 Quartz 4.0",
+    pageTitle: "배워서 남주자",
     pageTitleSuffix: "",
     enableSPA: true,
     enablePopovers: true,

--- a/quartz.config.ts
+++ b/quartz.config.ts
@@ -79,7 +79,13 @@ const config: QuartzConfig = {
       Plugin.AliasRedirects(),
       Plugin.ComponentResources(),
       Plugin.ContentPage(),
-      Plugin.FolderPage(),
+      Plugin.FolderPage({
+        sort: (f1, f2) => {
+          const d1 = new Date(String(f1.frontmatter?.created))
+          const d2 = new Date(String(f2.frontmatter?.created))
+          return d2.getTime() - d1.getTime()
+        }
+      }),
       Plugin.TagPage(),
       Plugin.ContentIndex({
         enableSiteMap: true,

--- a/quartz.config.ts
+++ b/quartz.config.ts
@@ -24,8 +24,8 @@ const config: QuartzConfig = {
       fontOrigin: "googleFonts",
       cdnCaching: true,
       typography: {
-        header: "Schibsted Grotesk",
-        body: "Source Sans Pro",
+        header: "Noto Sans Korean",
+        body: "Noto Sans Korean",
         code: "IBM Plex Mono",
       },
       colors: {

--- a/quartz/components/Explorer.tsx
+++ b/quartz/components/Explorer.tsx
@@ -10,7 +10,7 @@ import { i18n } from "../i18n"
 
 // Options interface defined in `ExplorerNode` to avoid circular dependency
 const defaultOptions = {
-  folderClickBehavior: "collapse",
+  folderClickBehavior: "link",
   folderDefaultState: "collapsed",
   useSavedState: true,
   mapFn: (node) => {

--- a/quartz/components/PageList.tsx
+++ b/quartz/components/PageList.tsx
@@ -1,6 +1,6 @@
 import { FullSlug, resolveRelative } from "../util/path"
 import { QuartzPluginData } from "../plugins/vfile"
-import { Date, getDate } from "./Date"
+import { formatDate, getDate } from "./Date"
 import { QuartzComponent, QuartzComponentProps } from "./types"
 import { GlobalConfiguration } from "../cfg"
 
@@ -42,12 +42,16 @@ export const PageList: QuartzComponent = ({ cfg, fileData, allFiles, limit, sort
       {list.map((page) => {
         const title = page.frontmatter?.title
         const tags = page.frontmatter?.tags ?? []
+        const fileCreated = new Date(String(page.frontmatter?.created))
+        function DateJSX({ date, locale }: Props) {
+          return <>{formatDate(date, locale)}</>
+        }
 
         return (
           <li class="section-li">
             <div class="section">
               <p class="meta">
-                {page.dates && <Date date={getDate(cfg, page)!} locale={cfg.locale} />}
+                {page.dates && <DateJSX date={fileCreated} locale={cfg.locale}/>}
               </p>
               <div class="desc">
                 <h3>

--- a/quartz/components/styles/listPage.scss
+++ b/quartz/components/styles/listPage.scss
@@ -11,7 +11,7 @@ li.section-li {
 
   & > .section {
     display: grid;
-    grid-template-columns: fit-content(8em) 3fr 1fr;
+    grid-template-columns: fit-content(9em) 3fr 1fr;
 
     @media all and ($mobile) {
       & > .tags {


### PR DESCRIPTION
# TL;DR
- 블로그 타이틀/locale 수정
- 옵시디언의 created를 파일 생성 날짜로 사용
- 폰트 변경: [Noto Sans Korean](https://fonts.google.com/noto/specimen/Noto+Sans+KR)
- 탐색기 클릭시 링크를 이동하도록 수정
- Closes #4